### PR TITLE
recursive 301s

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-simple-301-redirects
-====================
+# Simple 301 Redirects
+
 **Notice: This entire repository should be considered experimental. The stable version of this plugin should always be [downloaded from the WordPress Plugin Directory](https://wordpress.org/plugins/simple-301-redirects/ "Download the release version of Simple 301 Redirects").**
 
-Simple 301 Redirects is a popular URL Redirection plugin for WordPress
+Simple 301 Redirects is a popular URL Redirection plugin for WordPress.
+
+## Features
+
+  - Allows your users to 301 redirect any URL to any other from the WP Admin site.
+  - Supports simple globby wildcards (`/some/path/*/` -> `/somewhere/else/`)
+  - Resolves 301 chains into single redirects

--- a/wp-simple-301-redirects.php
+++ b/wp-simple-301-redirects.php
@@ -6,6 +6,8 @@ Description: Create a list of URLs that you would like to 301 redirect to anothe
 Version: 1.08a
 Author: Scott Nellé
 Author URI: http://www.scottnelle.com/
+Author: Mark Kennedy
+Author URI: https://github.com/mrmonkington
 */
 
 /*  Copyright 2009-2016  Scott Nellé  (email : contact@scottnelle.com)
@@ -439,7 +441,7 @@ if ( ! class_exists( 'Simple301redirects' ) ) {
 
 					// preg_quote will turn * into \*
 					$request = str_replace('\*','(.*)',$request);
-					$pattern = '/^' . str_replace( '/', '\/', rtrim( $request, '/' ) ) . '/';
+					$pattern = '/^' . rtrim( $request, '/' ) . '/';
 
 					// destination uses * as a replacement token for the first * match
 					// TODO possily remove this, it's confusing, right?

--- a/wp-simple-301-redirects.php
+++ b/wp-simple-301-redirects.php
@@ -469,9 +469,6 @@ if ( ! class_exists( 'Simple301redirects' ) ) {
 				return $request;
 			}
 			foreach($redirects as $key => $redirect) {
-				//pass
-				//echo $request['url'] . "\n";
-				//echo $redirect['request'] . "\n";
 				$dest_url = $this->match( $redirect, $request['url'] );
 				if( false !== $dest_url ) {
 					$request['url'] = $dest_url;


### PR DESCRIPTION
- [x ] Is this Pull Request ready for review?

**What does this Pull Request do?**

 - Fixes up the upstream interface-rewrite branch.
- Also flattens 301 chains, to help with VG's SEO efforts.

**Any background context you want to provide?**

The old version of s301r didn't allow more than 301s than the POST limit would support.

**What are the relevant Github Issues or Zendesk tickets?**

https://gntech.zendesk.com/inbox/conversations/1494

**Where can the reviewer see this in action?**

 - admin https://mark-vg247-com.dev.gamer-network.net/wp-admin/options-general.php?page=301options
 - site https://mark-vg247-com.dev.gamer-network.net/

**How should this be tested?**

Test adding, editing and removing 301s in the backend.

Test a redirect.

Test a redirect chain is resolved into a single 301. Here's one:

```
https://mark-vg247-com.dev.gamer-network.net/looptest
-> /2015/11/17/fallout-4-weapon-crafting-guide-3/
-> /2016/11/28/best-xbox-one-black-friday-deals-2016-bundles-games/
```

Use cURL to determine that it responds with a single redirect (use your u/p):

```
$ curl https://mark-vg247-com.dev.gamer-network.net/testloop -u <user>:<pass> -I
HTTP/1.1 301 Moved Permanently
Date: Wed, 13 Dec 2017 17:02:14 GMT
Server: Apache/2.4.10 (Debian)
Location: /2016/11/28/best-xbox-one-black-friday-deals-2016-bundles-games/
Content-Type: text/html; charset=UTF-8
```

