### PR TITLE
Factor out repeated calls to generate_hash function in redirect listing

### DIFF
--- a/wp-simple-301-redirects.php
+++ b/wp-simple-301-redirects.php
@@ -189,13 +189,14 @@ if ( ! class_exists( 'Simple301redirects' ) ) {
 			if ( ! empty( $redirects ) && is_array( $redirects ) ) {
 				foreach ($redirects as $index => $data) {
 					if ( ! empty( $data['request'] ) && ! empty( $data['destination'] ) ) {
+						$hash = $this->generate_hash($index);
 						?>
 						<tr>
 							<td>
-								<a href="<?php echo esc_url( $this->settings_url . '&s301r_action=edit&index=' . $index .'&hash=' . $this->generate_hash( $index ) ); ?>" aria-label="<?php esc_attr_e( 'Edit Redirect', 's301r' ); ?>"><?php echo esc_html( $data['request'] ); ?></a>
+								<a href="<?php echo esc_url( $this->settings_url . '&s301r_action=edit&index=' . $index .'&hash=' . $hash ); ?>" aria-label="<?php esc_attr_e( 'Edit Redirect', 's301r' ); ?>"><?php echo esc_html( $data['request'] ); ?></a>
 								<div class="row-actions">
-									<span class="edit"><a href="<?php echo esc_url( $this->settings_url . '&s301r_action=edit&index=' . $index .'&hash=' . $this->generate_hash( $index ) ); ?>"><?php esc_html_e( 'Edit', 's301r' ); ?></a> |</span>
-									<span class="trash"><a href="<?php echo esc_url( $this->settings_url . '&s301r_action=delete&index=' . $index .'&hash=' . $this->generate_hash( $index ) ); ?>"><?php esc_html_e( 'Delete', 's301r' ); ?></a></span>
+									<span class="edit"><a href="<?php echo esc_url( $this->settings_url . '&s301r_action=edit&index=' . $index .'&hash=' . $hash ); ?>"><?php esc_html_e( 'Edit', 's301r' ); ?></a> |</span>
+									<span class="trash"><a href="<?php echo esc_url( $this->settings_url . '&s301r_action=delete&index=' . $index .'&hash=' . $hash ); ?>"><?php esc_html_e( 'Delete', 's301r' ); ?></a></span>
 								</div>
 							</td>
 							<td>


### PR DESCRIPTION
The `generate_hash()` function was being called 3 times for each redirect entry on the redirect listing page.  This function in turn calls `get_redirect_by_index()` which in turn loads all redirects in to an assoc array.  I've adjusted things so that `generate_hash()` is called only once for each redirect entry.

This reduces page load time on my working copy from 17 seconds to 7 seconds.  There is definitely more optimisation work to be done here, but this gets editorial moving for now.